### PR TITLE
[ADD] depend on base_field_serialized to use serialized fields

### DIFF
--- a/report_aeroo/__openerp__.py
+++ b/report_aeroo/__openerp__.py
@@ -68,7 +68,7 @@ Reporting engine features:
     'author': 'Alistek Ltd, Simone Orsi - Domsense',
     'website': 'http://www.alistek.com',
     'complexity': "easy",
-    'depends': ['base', 'report'],
+    'depends': ['base', 'report', 'base_field_serialized'],
     "init_xml" : [],
     'update_xml': ["installer.xml", "report_view.xml", "data/report_aeroo_data.xml", "wizard/add_print_button_view.xml", "wizard/remove_print_button_view.xml", "security/ir.model.access.csv"],
     "license" : "GPL-3 or any later version",

--- a/report_aeroo/report_aeroo.py
+++ b/report_aeroo/report_aeroo.py
@@ -37,7 +37,7 @@ from tempfile import NamedTemporaryFile
 from openerp import report
 from openerp.report.report_sxw import report_sxw, report_rml
 from openerp.osv.orm import browse_record_list
-from openerp.report.pyPdf import PdfFileWriter, PdfFileReader
+from pyPdf import PdfFileWriter, PdfFileReader
 from openerp.addons.report_aeroo_ooo import report as rpt
 #import zipfile
 try:
@@ -168,8 +168,8 @@ class Aeroo_report(report_sxw):
     def getObjects_mod(self, cr, uid, ids, rep_type, context):
         table_obj = pooler.get_pool(cr.dbname).get(self.table)
         if rep_type=='aeroo':
-            return table_obj.browse(cr, uid, ids, list_class=browse_record_list, context=context)
-        return table_obj.browse(cr, uid, ids, list_class=browse_record_list, context=context)
+            return table_obj.browse(cr, uid, ids, context=context)
+        return table_obj.browse(cr, uid, ids, context=context)
 
     ##### Counter functions #####
     def _def_inc(self, aeroo_print):
@@ -801,16 +801,12 @@ class Aeroo_report(report_sxw):
                 [('report_name', '=', name)], context=context)
         if report_xml_ids:
             report_xml = ir_obj.browse(cr, uid, report_xml_ids[0], context=context)
-            report_xml.report_rml = None
-            report_xml.report_rml_content = None
-            report_xml.report_sxw_content_data = None
-            report_rml.report_sxw_content = None
-            report_rml.report_sxw = None
+            copies = report_xml.copies
             copies_ids = []
-            if not report_xml.report_wizard and report_xml>1:
+            if not report_xml.report_wizard and copies>1:
                 while(report_xml.copies):
                     copies_ids.extend(ids)
-                    report_xml.copies -= 1
+                    copies -= 1
             ids = copies_ids or ids
         else:
             title = ''

--- a/report_aeroo/report_xml.py
+++ b/report_aeroo/report_xml.py
@@ -54,7 +54,7 @@ class report_stylesheets(osv.osv):
     _description = 'Report Stylesheets'
 
     _columns = {
-        'name': fields.char('Name', size=64, required=True),
+        'name': fields.char('Name', required=True),
         'report_styles': fields.binary('Template Stylesheet', help='OpenOffice.org stylesheet (.odt)'),
 
     }
@@ -77,10 +77,10 @@ class report_mimetypes(osv.osv):
     _description = 'Report Mime-Types'
 
     _columns = {
-        'name': fields.char('Name', size=64, required=True, readonly=True),
-        'code': fields.char('Code', size=16, required=True, readonly=True),
-        'compatible_types': fields.char('Compatible Mime-Types', size=128, readonly=True),
-        'filter_name': fields.char('Filter Name', size=128, readonly=True),
+        'name': fields.char('Name', required=True, readonly=True),
+        'code': fields.char('Code', required=True, readonly=True),
+        'compatible_types': fields.char('Compatible Mime-Types', readonly=True),
+        'filter_name': fields.char('Filter Name', readonly=True),
 
     }
 
@@ -344,7 +344,7 @@ class report_xml(osv.osv):
 
     _columns = {
         'charset': fields.selection(_get_encodings, string='Charset', required=True),
-        'content_fname': fields.char('Override Extension', size=64, help='Here you can override output file extension'),
+        'content_fname': fields.char('Override Extension', help='Here you can override output file extension'),
         'styles_mode': fields.selection([
             ('default', 'Not used'),
             ('global', 'Global'),
@@ -361,7 +361,7 @@ class report_xml(osv.osv):
             ('parser', 'Parser'),
         ], 'Template source', select=True),
         'parser_def': fields.text('Parser Definition'),
-        'parser_loc': fields.char('Parser location', size=128,
+        'parser_loc': fields.char('Parser location',
             help="Path to the parser location. Beginning of the path must be start with the module name!\nLike this: {module name}/{path to the parser.py file}"),
         'parser_state': fields.selection([
             ('default', _('Default')),
@@ -377,9 +377,9 @@ class report_xml(osv.osv):
         'report_wizard': fields.boolean('Report Wizard'),
         'copies': fields.integer('Number of Copies'),
         'fallback_false': fields.boolean('Disable Format Fallback'),
-        'xml_id': fields.function(_get_xml_id, type='char', size=128, string="XML ID",
+        'xml_id': fields.function(_get_xml_id, type='char', string="XML ID",
             method=True, help="ID of the report defined in xml file"),
-        'extras': fields.function(_get_extras, method=True, type='char', size='256', string='Extra options'),
+        'extras': fields.function(_get_extras, method=True, type='char', string='Extra options'),
         'deferred': fields.selection([
             ('off', _('Off')),
             ('adaptive', _('Adaptive')),


### PR DESCRIPTION
This depends on https://github.com/OCA/server-tools/pull/60. With the fixes below, I can run an odt report with the git version as of today.

[FIX] import from pyPdf
[FIX] don't pass list_class (which is browse_record_list anyway)
[FIX] don't assign to an active record's members. This causes database
writes
[FIX] remove deprecated string sizes, especially the one that is a
string itself and causes trouble in the ORM
