### PR TITLE
[FIX] check dependencies only when the module is installed

### DIFF
--- a/report_aeroo_ooo/DocumentConverter.py
+++ b/report_aeroo_ooo/DocumentConverter.py
@@ -36,15 +36,19 @@ try:
 except ImportError:
     from StringIO import StringIO
 
-import uno
-import unohelper
-from com.sun.star.beans import PropertyValue
-from com.sun.star.uno import Exception as UnoException
-from com.sun.star.connection import NoConnectException, ConnectionSetupException
-from com.sun.star.beans import UnknownPropertyException
-from com.sun.star.lang import IllegalArgumentException
-from com.sun.star.io import XOutputStream
-from com.sun.star.io import IOException
+try:
+    import uno
+    import unohelper
+    from com.sun.star.beans import PropertyValue
+    from com.sun.star.uno import Exception as UnoException
+    from com.sun.star.connection import NoConnectException, ConnectionSetupException
+    from com.sun.star.beans import UnknownPropertyException
+    from com.sun.star.lang import IllegalArgumentException
+    from com.sun.star.io import XOutputStream
+    from com.sun.star.io import IOException
+except ImportError:
+    logging.exception('Failed to import necessary UNO components', exc_info=True)
+
 from openerp.tools.translate import _
 
 logger = logging.getLogger(__name__)

--- a/report_aeroo_ooo/__init__.py
+++ b/report_aeroo_ooo/__init__.py
@@ -29,18 +29,6 @@
 #
 ##############################################################################
 
-check_list = [
-    'import uno',
-    'import unohelper',
-    'from com.sun.star.beans import PropertyValue',
-    'from com.sun.star.uno import Exception as UnoException',
-    'from com.sun.star.connection import NoConnectException, ConnectionSetupException',
-    'from com.sun.star.beans import UnknownPropertyException',
-    'from com.sun.star.lang import IllegalArgumentException',
-    'from com.sun.star.io import XOutputStream',
-    'from com.sun.star.io import IOException',
-]
-
 DEFAULT_OPENOFFICE_PATH = [
     "C:\Program Files\OpenOffice.org 3\Basis\program",
     "C:\Program Files\OpenOffice.org 3\program",
@@ -66,15 +54,5 @@ if sys.platform=='win32':
     except WindowsError, e:
         sys.path.extend(platform.machine()=='x86' and DEFAULT_OPENOFFICE_PATH or DEFAULT_OPENOFFICE_PATH_AMD64)
 
-from check_deps import check_deps
-check_deps(check_list)
-
-try:
-    import DocumentConverter
-except ImportError, e:
-    print e
-
 import installer
 import report
-
-

--- a/report_aeroo_ooo/__openerp__.py
+++ b/report_aeroo_ooo/__openerp__.py
@@ -59,4 +59,7 @@ ods -> csv
     "license" : "GPL-3 or any later version",
     'installable': True,
     'active': False,
+    "external_dependencies": {
+            'python': ['uno', 'unohelper'],
+        }
 }

--- a/report_aeroo_ooo/installer.py
+++ b/report_aeroo_ooo/installer.py
@@ -43,8 +43,6 @@ except ImportError:
     from StringIO import StringIO
 from openerp.tools.translate import _
 
-from DocumentConverter import DocumentConversionException
-
 _url = 'http://www.alistek.com/aeroo_banner/v7_0_report_aeroo_ooo.png'
 
 import threading
@@ -111,6 +109,8 @@ class aeroo_config_installer(osv.osv_memory):
         return data
 
     def check(self, cr, uid, ids, context=None):
+        from DocumentConverter import DocumentConversionException
+
         config_obj = self.pool.get('oo.config')
         data = self.read(cr, uid, ids, ['host','port','ooo_restart_cmd'])[0]
         del data['id']
@@ -165,3 +165,18 @@ class aeroo_config_installer(osv.osv_memory):
         'link':'http://www.alistek.com/wiki/index.php/Aeroo_Reports_Linux_server#Installation_.28Dependencies_and_Base_system_setup.29',
     }
 
+    def _register_hook(self, cr):
+        check_list = [
+            'import uno',
+            'import unohelper',
+            'from com.sun.star.beans import PropertyValue',
+            'from com.sun.star.uno import Exception as UnoException',
+            'from com.sun.star.connection import NoConnectException, ConnectionSetupException',
+            'from com.sun.star.beans import UnknownPropertyException',
+            'from com.sun.star.lang import IllegalArgumentException',
+            'from com.sun.star.io import XOutputStream',
+            'from com.sun.star.io import IOException',
+        ]
+
+        from check_deps import check_deps
+        check_deps(check_list)

--- a/report_aeroo_ooo/report.py
+++ b/report_aeroo_ooo/report.py
@@ -31,7 +31,11 @@
 
 from openerp.osv import osv,fields
 from openerp import netsvc
-from DocumentConverter import DocumentConverter
+try:
+    from DocumentConverter import DocumentConverter
+except NameError:
+    class DocumentConverter:
+        pass
 
 class OpenOffice_service (DocumentConverter):
 


### PR DESCRIPTION
Also list uno and unohelper as external dependency so that
report_aeroo_ooo can't be installed in the first place if this
module is missing.
