### PR TITLE
Fixed translation sync issue

### DIFF
--- a/report_aeroo/translate.py
+++ b/report_aeroo/translate.py
@@ -75,7 +75,7 @@ def extend_trans_generate(lang, modules, cr):
 
     _to_translate = []
     def push_translation(module, type, name, id, source, comments=None):
-        tuple = (module, source, name, id, type, comments or [])
+        tuple = (module, encode(source), name, id, type, comments or [])
         # empty and one-letter terms are ignored, they probably are not meant to be
         # translated, and would be very hard to translate anyway.
         if not source or len(source.strip()) <= 1:


### PR DESCRIPTION
When the source of the translation includes unicode characters syncing terms fails because unable to sort _to_translate list (line 371 of translate.py). This pull request address this issue by encoding translation source since it is not necessarily in ascii.
