### PR TITLE
Fix breaking of QWeb reports

### DIFF
--- a/report_aeroo/report_controller.py
+++ b/report_aeroo/report_controller.py
@@ -20,6 +20,7 @@
 ##############################################################################
 from openerp.addons.report.controllers.main import ReportController
 from openerp.addons.web.http import route
+import simplejson
 
 class ReportController(ReportController):
 
@@ -28,8 +29,9 @@ class ReportController(ReportController):
         '/report/<path:converter>/<reportname>/<docids>',
     ], type='http', auth='user', website=True, multilang=True)
     def report_routes(self, reportname, docids=None, converter=None, **data):
-        data_context = simplejson.loads(data['context'])
-        if not docids:
+        context = data.get('context')
+        if context and not docids:
+            data_context = simplejson.loads(context)
             docids_list = data_context.get('active_ids')
             docids = ",".join(str(x) for x in docids_list)
             


### PR DESCRIPTION
Modification applied e80d8872fd1f050fa495eb3975f5545e549aa8bf in report_controller.py breaks qweb reports (twice):

- unknown reference to simplejson as it is not explicitly imported
- function is called without context by qweb reports

This PR fixes it.